### PR TITLE
Correct a bug when unmounting component if autoplay is on

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -63,6 +63,11 @@ class Slider extends React.Component {
   componentWillUnmount() {
     typeof window !== 'undefined' && // eslint-disable-line no-unused-expressions
       window.removeEventListener('resize', this.updateResponsiveView);
+
+    if (this.autoSlider) {
+      this.autoSlider.pause();
+      this.autoSlider = null;
+    }
   }
 
   updateResponsiveView() {


### PR DESCRIPTION
Correct a bug when unmounting component if autoplay is on. After component unmounts, setInterval callback was still being called causing a potential memory leak.