### PR TITLE
Move dependency to `styled-components` into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "react": "^16.2.0",
-    "styled-components": "^3.1.6"
+    "styled-components": "^4.1.3"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --color --config webpack.config.dev.js",
     "build": "rimraf build && cross-env NODE_ENV=production babel src --ignore '**/*__tests__*/**, **/*Root.js, **/*example.js' -d build",
     "test": "cross-env NODE_ENV=test jest --coverage",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prop-types": "^15.6.0",
     "react-dom": "^16.2.0",
     "react-hot-loader": "^4.0.0-rc.0",
+    "styled-components": "^4.1.3",
     "style-loader": "^0.23.1",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack": "^4.29.6",
@@ -61,8 +62,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "dependencies": {
-    "react": "^16.2.0",
-    "styled-components": "^4.1.3"
+    "react": "^16.2.0"
   },
   "peerDependencies": {
     "react": "^16.2.0",


### PR DESCRIPTION
Hi @ItsMrAkhil,

we've ran into a `styled-components` warning because of `react-styled-carousel`:

> It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles not rendering properly, errors happening during rehydration process and makes your application bigger without a good reason.

(see: https://styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page)

The root cause is this:
https://github.com/ItsMrAkhil/react-styled-carousel/blob/9f61846c4f243c4e673c491525b7a31a20a87cd4/package.json#L63-L69

`react-styled-carousel` has a direct dependency to `styled-components` and thus installs it redundantly in our project.

This PR fixes the issue, by:

1. Moving `styled-components` to "devDependencies", so it's available for development.
2. Syncing the version-constraint of `styled-components` in "peerDependencies" with the one in "devDependencies"

This is following the recommendations from `styled-components` itself:
https://styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library

Also, this PR adds a "prepare" npm script. This was necessary to test our fork. "prepare" runs when a package is installed via a git repo address, to create fresh build artifacts that otherwise would be absent from the repository.

See also: https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts
> If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

It also runs before `npm publish`, so it'll probably spare you the extra build step.

Thanks :heart: for your work on this package!